### PR TITLE
国名の背後に写真の追加&editファイルの修正

### DIFF
--- a/database/seeders/CountrySeeder.php
+++ b/database/seeders/CountrySeeder.php
@@ -18,12 +18,13 @@ class CountrySeeder extends Seeder
     {
         DB::table('countries')->insert([
                 'country_name' => '日本',
-                'image' =>'https://res.cloudinary.com/dhmmkcidj/image/upload/v1677479646/UQrNeDUsFwNDA5som51RjgcBgwXeB0rD26oxNduqMTU_sl4u1e.jpg',
+                'image' => 'https://res.cloudinary.com/dhmmkcidj/image/upload/v1677479646/UQrNeDUsFwNDA5som51RjgcBgwXeB0rD26oxNduqMTU_sl4u1e.jpg',
                 'created_at' => new DateTime(),
                 'updated_at' => new DateTime(),
             ]);
         DB::table('countries')->insert([
                 'country_name' => '英国',
+                'image' => 'https://res.cloudinary.com/dhmmkcidj/image/upload/v1677576147/%E3%82%BF%E3%82%99%E3%82%A6%E3%83%B3%E3%83%AD%E3%83%BC%E3%83%88%E3%82%99_4_dzbcim.jpg',
                 'created_at' => new DateTime(),
                 'updated_at' => new DateTime(),
             ]);

--- a/public/css/country_name_image.css
+++ b/public/css/country_name_image.css
@@ -1,0 +1,17 @@
+.country_image {
+    position: relative;
+    text-align: center;
+}
+.country_img {
+    width: 50%;
+}
+.country_name {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%,-50%);
+    border:  solid 2px;                             
+    display:  inline-block;                         
+    padding: 10px 20px;                             
+    color: white;
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,0 +1,5 @@
+.country {
+  background-size: contain;
+  background-position: center;
+  height: 400px; /* 画像の高さに合わせて調整してください */
+}

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -4,10 +4,13 @@
         <meta charset="utf-8">
         <title>Traveler</title>
         <!-- Fonts -->
-        <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+        <link href="{{ secure_asset('/css/country_name_image.css') }}" rel="stylesheet">
     </head>
     <body>
-        <h1>{{ $country->country_name }}</h1>
+        <div class="country_image">
+            <image class="country_img" src={{ $country->image }} width="50%" alt="国の画像"/>
+            <h1 class=country_name >{{ $country->country_name }}</h1>
+        </div>
         <a href='/countries/{{ $country->id}}/posts/create'>あなたのお気に入りをシェアしよう！</a>
         @foreach ($posts as $post)
         <div class="post">

--- a/resources/views/countries/show.blade.php
+++ b/resources/views/countries/show.blade.php
@@ -4,10 +4,13 @@
         <meta charset="utf-8">
         <title>Traveler</title>
         <!-- Fonts -->
-        <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+        <link href="{{ secure_asset('/css/country_name_image.css') }}" rel="stylesheet">
     </head>
     <body>
-        <h1>{{ $country->country_name }}</h1>
+        <div class="country_image">
+            <image class="country_img" src={{ $country->image }} width="50%" alt="国の画像"/>
+            <h1 class=country_name >{{ $country->country_name }}</h1>
+        </div>
         <a href='/countries/{{ $country->id}}/posts/create'>あなたのお気に入りをシェアしよう！</a>
         @foreach ($posts as $post)
         <div class="post">

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -25,9 +25,11 @@
                 <h2>画像をアップロード</h2>
                 
                 <div class="image">
-                <image id='old_img' src={{ $post->image }} width="50%" alt="画像が読み取れません"/>
+                    @if ($post->image)
+                        <image id='old_img' src={{ $post->image }} width="50%" alt="画像が読み取れません"/>
+                    @endif    
                 </div>
-                <input type="file" id= "image" name="image" onchange="ChangeHidden()" value="{{ $post->image }}"/>
+                <input type="file" id= "image" name="image" value="{{ old('image') }}"/>
                 <p class="image__error" style="color:red">{{ $errors->first('image') }}</p>
             </div>
             <div>


### PR DESCRIPTION
国名に背景画面を追加し、中央揃えにした。また、editファイルで元々写真が挿入されていない場合にedit画面に何も表示しないようにした。