### PR TITLE
gamilを使ってのpasswordリセットの設定完了

### DIFF
--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -42,7 +42,7 @@ class NewPasswordController extends Controller
             $request->only('email', 'password', 'password_confirmation', 'token'),
             function ($user, $password) {
                 $user->forceFill([
-                    'password' => Hash::make($request->password)
+                    'password' => Hash::make($password)
                 ])->setRememberToken(Str::random(60));
                 
                 $user->save();


### PR DESCRIPTION
gmailでの送信は内容によりスパム扱いになりやすく、accountがbanされる可能性があるため、送信頻度を考える。